### PR TITLE
feat: initial class-based router decorators

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json']
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  root: true
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# trpc-routing-controllers
+
+A tiny experiment that brings class-based routers and decorators to tRPC v10.
+
+```ts
+import { z } from 'zod';
+import { initTRPC } from '@trpc/server';
+import { Router, Query, Mutation, Ctx, Input, UseZod, createClassRouter } from 'trpc-routing-controllers';
+
+@Router('users')
+class UsersController {
+  @Query('hello')
+  @UseZod(z.object({ name: z.string() }))
+  hello(@Input() input: { name: string }) {
+    return `hello ${input.name}`;
+  }
+}
+
+const t = initTRPC.context().create();
+const { router } = createClassRouter({ t, controllers: [new UsersController()] });
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "trpc-routing-controllers",
+  "version": "0.1.0",
+  "description": "Decorators and class-based routing for tRPC v10",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "lint": "eslint .",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "peerDependencies": {
+    "@trpc/server": "^10.0.0",
+    "zod": "^3.23.0"
+  },
+  "dependencies": {
+    "reflect-metadata": "^0.1.13"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.0.0",
+    "prettier": "^3.0.0",
+    "tsup": "^7.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.0.0",
+    "@trpc/server": "^10.0.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -1,0 +1,94 @@
+import type { initTRPC } from '@trpc/server';
+import type { z } from 'zod';
+import {
+  getMethodMetadata,
+  getParamMetadata,
+  getRouterMetadata,
+  MethodMetadata,
+} from './metadata';
+import type { Middleware, ProcedureOptions, TRPCContext, AuthGuard } from './types';
+import { createRateLimitMiddleware } from './rateLimit';
+
+export interface CreateClassRouterOptions {
+  t: ReturnType<typeof initTRPC.context<TRPCContext>['create']>;
+  controllers: any[];
+}
+
+function toCamel(str: string) {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}
+
+function authMiddleware(guards: AuthGuard[]): Middleware {
+  return async ({ ctx, next }) => {
+    for (const g of guards) {
+      const ok = await g(ctx);
+      if (!ok) {
+        throw new Error('UNAUTHORIZED');
+      }
+    }
+    return next();
+  };
+}
+
+export function createClassRouter(options: CreateClassRouterOptions) {
+  const { t, controllers } = options;
+  const rootProcedures: Record<string, any> = {};
+
+  for (const controller of controllers) {
+    const ctor = controller.constructor;
+    const classMeta = getRouterMetadata(ctor);
+    const base = classMeta.base ?? toCamel(ctor.name);
+
+    const procedures: Record<string, any> = {};
+    const proto = Object.getPrototypeOf(controller);
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (key === 'constructor') continue;
+      const meta = getMethodMetadata(proto, key) as MethodMetadata | undefined;
+      if (!meta) continue;
+      const name = meta.name ?? key;
+      let proc = t.procedure;
+
+      const combinedMiddlewares: Middleware[] = [];
+      if (classMeta.middlewares) combinedMiddlewares.push(...classMeta.middlewares);
+      if (meta.middlewares) combinedMiddlewares.push(...meta.middlewares);
+      if (classMeta.auth) combinedMiddlewares.push(authMiddleware(classMeta.auth));
+      if (meta.auth) combinedMiddlewares.push(authMiddleware(meta.auth));
+      if (classMeta.rateLimit) combinedMiddlewares.push(createRateLimitMiddleware(classMeta.rateLimit));
+      if (meta.rateLimit) combinedMiddlewares.push(createRateLimitMiddleware(meta.rateLimit));
+      for (const mw of combinedMiddlewares) {
+        proc = proc.use(mw);
+      }
+      if (classMeta.meta) proc = proc.meta(classMeta.meta);
+      if (meta.meta) proc = proc.meta(meta.meta);
+      if (meta.deprecated) proc = proc.meta({ deprecated: meta.deprecated });
+      if (meta.input) proc = proc.input(meta.input as z.ZodTypeAny);
+      if (meta.output) proc = proc.output(meta.output as z.ZodTypeAny);
+
+      const paramMeta = getParamMetadata(proto, key);
+      const handler = async (opts: { ctx: any; input: any }) => {
+        const args: any[] = [];
+        for (const p of paramMeta) {
+          args[p.index] = p.type === 'ctx' ? opts.ctx : opts.input;
+        }
+        return (controller as any)[key](...args);
+      };
+
+      if (meta.type === 'mutation') {
+        procedures[name] = proc.mutation(handler);
+      } else if (meta.type === 'subscription') {
+        procedures[name] = proc.subscription(handler as any);
+      } else {
+        procedures[name] = proc.query(handler);
+      }
+    }
+
+    if (!rootProcedures[base]) {
+      rootProcedures[base] = t.router(procedures);
+    } else {
+      rootProcedures[base] = t.mergeRouters(rootProcedures[base], t.router(procedures));
+    }
+  }
+
+  const router = t.router(rootProcedures);
+  return { router };
+}

--- a/src/core/decorators.ts
+++ b/src/core/decorators.ts
@@ -1,0 +1,137 @@
+import type { z } from 'zod';
+import {
+  addParamMetadata,
+  getMethodMetadata,
+  getRouterMetadata,
+  setMethodMetadata,
+  setRouterMetadata,
+} from './metadata';
+import type { Middleware, ProcedureOptions, AuthGuard, RateLimitOptions } from './types';
+
+function mergeArrays<T>(...arrays: (T[] | undefined)[]): T[] | undefined {
+  const result = arrays.filter(Boolean).flat() as T[];
+  return result.length ? result : undefined;
+}
+
+export function Router(base?: string, opts?: { middlewares?: Middleware[]; meta?: Record<string, any>; auth?: AuthGuard | AuthGuard[]; rateLimit?: RateLimitOptions }) {
+  return function (target: Function) {
+    const prev = getRouterMetadata(target);
+    const authArr = opts?.auth ? (Array.isArray(opts.auth) ? opts.auth : [opts.auth]) : undefined;
+    setRouterMetadata(target, {
+      ...prev,
+      base,
+      middlewares: mergeArrays(prev.middlewares, opts?.middlewares),
+      meta: { ...prev.meta, ...opts?.meta },
+      auth: mergeArrays(prev.auth, authArr),
+      rateLimit: opts?.rateLimit ?? prev.rateLimit,
+    });
+  };
+}
+
+export function UseMiddlewares(...middlewares: Middleware[]) {
+  return function (target: any, propertyKey?: string | symbol) {
+    if (propertyKey) {
+      const meta = getMethodMetadata(target, propertyKey) || { type: 'query' };
+      meta.middlewares = mergeArrays(meta.middlewares, middlewares);
+      setMethodMetadata(target, propertyKey, meta);
+    } else {
+      const meta = getRouterMetadata(target);
+      meta.middlewares = mergeArrays(meta.middlewares, middlewares);
+      setRouterMetadata(target, meta);
+    }
+  };
+}
+
+function procedureDecorator(type: 'query' | 'mutation' | 'subscription') {
+  return function (name?: string, opts?: ProcedureOptions) {
+    return function (target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+      const meta = getMethodMetadata(target, propertyKey) || { type };
+      meta.type = type;
+      meta.name = name;
+      if (opts?.input) meta.input = opts.input;
+      if (opts?.output) meta.output = opts.output;
+      meta.middlewares = mergeArrays(meta.middlewares, opts?.middlewares);
+      if (opts?.meta) meta.meta = { ...meta.meta, ...opts.meta };
+      if (opts?.deprecated !== undefined) meta.deprecated = opts.deprecated;
+      if (opts?.rateLimit) meta.rateLimit = opts.rateLimit;
+      if (opts?.auth) meta.auth = mergeArrays(meta.auth, Array.isArray(opts.auth) ? opts.auth : [opts.auth]);
+      setMethodMetadata(target, propertyKey, meta);
+      return descriptor;
+    };
+  };
+}
+
+export const Query = procedureDecorator('query');
+export const Mutation = procedureDecorator('mutation');
+export const Subscription = procedureDecorator('subscription');
+
+export function UseZod(input?: z.ZodTypeAny, output?: z.ZodTypeAny) {
+  return function (target: any, propertyKey: string | symbol) {
+    const meta = getMethodMetadata(target, propertyKey) || { type: 'query' };
+    if (input) meta.input = input;
+    if (output) meta.output = output;
+    setMethodMetadata(target, propertyKey, meta);
+  };
+}
+
+export function Ctx() {
+  return function (target: any, propertyKey: string | symbol, parameterIndex: number) {
+    addParamMetadata(target, propertyKey, { index: parameterIndex, type: 'ctx' });
+  };
+}
+
+export function Input() {
+  return function (target: any, propertyKey: string | symbol, parameterIndex: number) {
+    addParamMetadata(target, propertyKey, { index: parameterIndex, type: 'input' });
+  };
+}
+
+export function Auth(guard: AuthGuard) {
+  return function (target: any, propertyKey?: string | symbol) {
+    if (propertyKey) {
+      const meta = getMethodMetadata(target, propertyKey) || { type: 'query' };
+      meta.auth = mergeArrays(meta.auth, [guard]);
+      setMethodMetadata(target, propertyKey, meta);
+    } else {
+      const meta = getRouterMetadata(target);
+      meta.auth = mergeArrays(meta.auth, [guard]);
+      setRouterMetadata(target, meta);
+    }
+  };
+}
+
+export function Meta(meta: Record<string, any>) {
+  return function (target: any, propertyKey?: string | symbol) {
+    if (propertyKey) {
+      const m = getMethodMetadata(target, propertyKey) || { type: 'query' };
+      m.meta = { ...m.meta, ...meta };
+      setMethodMetadata(target, propertyKey, m);
+    } else {
+      const m = getRouterMetadata(target);
+      m.meta = { ...m.meta, ...meta };
+      setRouterMetadata(target, m);
+    }
+  };
+}
+
+export function Deprecated(message?: string) {
+  return function (target: any, propertyKey: string | symbol) {
+    const meta = getMethodMetadata(target, propertyKey) || { type: 'query' };
+    meta.deprecated = message || true;
+    setMethodMetadata(target, propertyKey, meta);
+  };
+}
+
+export function RateLimit(opts: RateLimitOptions) {
+  return function (target: any, propertyKey?: string | symbol) {
+    if (propertyKey) {
+      const meta = getMethodMetadata(target, propertyKey) || { type: 'query' };
+      meta.rateLimit = opts;
+      setMethodMetadata(target, propertyKey, meta);
+    } else {
+      const meta = getRouterMetadata(target);
+      meta.rateLimit = opts;
+      setRouterMetadata(target, meta);
+    }
+  };
+}

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -1,0 +1,58 @@
+import 'reflect-metadata';
+import type { AuthGuard, Middleware, ProcedureOptions, RateLimitOptions } from './types';
+import { z } from 'zod';
+
+export const CLASS_METADATA = Symbol('trpc:class');
+export const METHOD_METADATA = Symbol('trpc:method');
+export const PARAM_METADATA = Symbol('trpc:param');
+
+export interface RouterMetadata {
+  base?: string;
+  middlewares?: Middleware[];
+  meta?: Record<string, any>;
+  auth?: AuthGuard[];
+  rateLimit?: RateLimitOptions;
+}
+
+export interface MethodMetadata {
+  type: 'query' | 'mutation' | 'subscription';
+  name?: string;
+  input?: z.ZodTypeAny;
+  output?: z.ZodTypeAny;
+  middlewares?: Middleware[];
+  meta?: Record<string, any>;
+  deprecated?: boolean | string;
+  rateLimit?: RateLimitOptions;
+  auth?: AuthGuard[];
+}
+
+export interface ParamMetadata {
+  index: number;
+  type: 'ctx' | 'input';
+}
+
+export function getRouterMetadata(target: Function): RouterMetadata {
+  return Reflect.getMetadata(CLASS_METADATA, target) || {};
+}
+
+export function setRouterMetadata(target: Function, meta: RouterMetadata) {
+  Reflect.defineMetadata(CLASS_METADATA, meta, target);
+}
+
+export function getMethodMetadata(target: any, propertyKey: string | symbol): MethodMetadata | undefined {
+  return Reflect.getMetadata(METHOD_METADATA, target, propertyKey);
+}
+
+export function setMethodMetadata(target: any, propertyKey: string | symbol, meta: MethodMetadata) {
+  Reflect.defineMetadata(METHOD_METADATA, meta, target, propertyKey);
+}
+
+export function getParamMetadata(target: any, propertyKey: string | symbol): ParamMetadata[] {
+  return Reflect.getMetadata(PARAM_METADATA, target, propertyKey) || [];
+}
+
+export function addParamMetadata(target: any, propertyKey: string | symbol, meta: ParamMetadata) {
+  const existing = getParamMetadata(target, propertyKey);
+  existing.push(meta);
+  Reflect.defineMetadata(PARAM_METADATA, existing, target, propertyKey);
+}

--- a/src/core/rateLimit.ts
+++ b/src/core/rateLimit.ts
@@ -1,0 +1,26 @@
+import type { Middleware } from './types';
+import type { RateLimitOptions } from './types';
+
+interface StoreItem {
+  points: number;
+  expires: number;
+}
+
+const store = new Map<string, StoreItem>();
+
+export function createRateLimitMiddleware(opts: RateLimitOptions): Middleware {
+  return async ({ ctx, path, next }) => {
+    const key = `${opts.key ?? 'global'}:${path}`;
+    const now = Date.now();
+    const item = store.get(key);
+    if (item && item.expires > now) {
+      if (item.points >= opts.points) {
+        throw new Error('Rate limit exceeded');
+      }
+      item.points++;
+    } else {
+      store.set(key, { points: 1, expires: now + opts.durationSec * 1000 });
+    }
+    return next();
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export type TRPCContext = unknown;
+
+export type Middleware = (opts: {
+  type: 'query' | 'mutation' | 'subscription';
+  path: string;
+  ctx: TRPCContext;
+  input: unknown;
+  next: () => Promise<unknown>;
+}) => Promise<unknown>;
+
+export type AuthGuard = (ctx: TRPCContext) => boolean | Promise<boolean>;
+
+export interface RateLimitOptions {
+  key?: string;
+  points: number;
+  durationSec: number;
+}
+
+export interface ProcedureOptions {
+  input?: z.ZodTypeAny;
+  output?: z.ZodTypeAny;
+  middlewares?: Middleware[];
+  meta?: Record<string, any>;
+  deprecated?: boolean | string;
+  rateLimit?: RateLimitOptions;
+  auth?: AuthGuard | AuthGuard[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * from './core/decorators';
+export * from './core/builder';
+export * from './core/types';

--- a/tests/builder.spec.ts
+++ b/tests/builder.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+import {
+  Router,
+  Query,
+  Mutation,
+  Ctx,
+  Input,
+  UseZod,
+  Auth,
+  UseMiddlewares,
+  createClassRouter,
+} from '../src';
+
+interface CtxType {
+  user?: { id: string };
+}
+
+const t = initTRPC.context<CtxType>().create();
+
+@Router('users')
+@UseMiddlewares(async ({ next }) => next())
+class UsersController {
+  @Query('hello')
+  @UseZod(z.object({ name: z.string() }))
+  hello(@Input() input: { name: string }) {
+    return `hello ${input.name}`;
+  }
+
+  @Mutation('add', { auth: (ctx) => !!ctx.user })
+  @UseZod(z.object({ id: z.string() }))
+  add(@Ctx() ctx: CtxType, @Input() input: { id: string }) {
+    return { id: input.id, user: ctx.user?.id };
+  }
+}
+
+describe('createClassRouter', () => {
+  const { router } = createClassRouter({ t, controllers: [new UsersController()] });
+  it('executes query', async () => {
+    const caller = router.createCaller({});
+    const res = await caller.users.hello({ name: 'Alice' });
+    expect(res).toBe('hello Alice');
+  });
+
+  it('fails zod validation', async () => {
+    const caller = router.createCaller({});
+    // @ts-expect-error
+    await expect(caller.users.hello({ name: 1 })).rejects.toBeTruthy();
+  });
+
+  it('runs auth guard', async () => {
+    const caller = router.createCaller({ user: { id: '1' } });
+    const res = await caller.users.add({ id: 'x' });
+    expect(res.user).toBe('1');
+    const caller2 = router.createCaller({});
+    await expect(caller2.users.add({ id: 'x' })).rejects.toBeTruthy();
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "types": ["node", "vitest"],
+    "sourceMap": true
+  },
+  "include": ["src", "tests", "examples"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- add decorators for tRPC class routers
- provide builder to create routers from decorated classes
- include simple rate limiter and example tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@trpc%2fserver)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689667363d3c8322b6be32206c1a2fad