### PR TITLE
chore: set release workflow environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment: main
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- use `main` environment for release workflow to access `NPM_TOKEN`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68970c93c6ac832293560de12caa2bb4