### PR TITLE
feat: add full app example

### DIFF
--- a/examples/full-app/README.md
+++ b/examples/full-app/README.md
@@ -1,0 +1,26 @@
+# Full tRPC Decorators App
+
+Exemplo completo usando a biblioteca de decorators para tRPC.
+
+## Instalação
+
+```bash
+cd examples/full-app
+npm i
+```
+
+## Scripts
+
+- `npm run dev` – inicia o servidor em modo desenvolvimento com tsx.
+- `npm run build` – compila para `dist/` em ESM.
+- `npm run start` – executa o build compilado.
+- `npm run test` – roda os testes com Vitest.
+- `npm run test:ci` – roda os testes no modo CI.
+- `npm run typecheck` – checagem de tipos sem emitir arquivos.
+- `npm run caller` – executa o cliente de exemplo com `createCaller`.
+
+O servidor expõe a API tRPC em `http://localhost:3000/trpc`.
+
+## Arquitetura
+
+Os controllers usam decorators da biblioteca (importada de `../../dist`) para definir rotas, validações, middlewares e guards. O `createClassRouter` monta o router a partir das classes e o `createCaller` permite chamadas tipadas no server e cliente.

--- a/examples/full-app/package.json
+++ b/examples/full-app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "type-trpc-full-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "preinstall": "npm -C ../.. run build",
+    "dev": "tsx src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "test": "vitest",
+    "test:ci": "vitest run --reporter=basic --no-threads",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "caller": "tsx src/client/caller.ts"
+  },
+  "dependencies": {
+    "type-trpc": "file:../..",
+    "@trpc/server": "^11.0.0",
+    "express": "^4.18.2",
+    "zod": "^3.23.8",
+    "superjson": "^2.2.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.0.0",
+    "tsx": "^4.6.1",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/examples/full-app/src/client/caller.ts
+++ b/examples/full-app/src/client/caller.ts
@@ -1,0 +1,16 @@
+import { createCaller } from '../server';
+
+async function main() {
+  const caller = createCaller({ user: { id: 'u1', role: 'admin' } });
+  const user = await caller.users.create({ name: 'Alice', email: 'alice@example.com' });
+  // expect: { id: string; name: string; email: string; createdAt: Date }
+  console.log('created', user);
+  const fetched = await caller.users.getById({ id: user.id });
+  // expect: typeof user | undefined
+  console.log('fetched', fetched);
+  const doubled = await caller.math.double({ x: 5 });
+  // expect: number
+  console.log('double', doubled);
+}
+
+main();

--- a/examples/full-app/src/context.ts
+++ b/examples/full-app/src/context.ts
@@ -1,0 +1,3 @@
+export interface AppContext {
+  user?: { id: string; role: 'user' | 'admin' };
+}

--- a/examples/full-app/src/controllers/math.controller.ts
+++ b/examples/full-app/src/controllers/math.controller.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { Router, Query, UseZod, Ctx, Input } from 'type-trpc';
+import type { AppContext } from '../context';
+
+@Router('math')
+export class MathController {
+  @Query('double')
+  @UseZod(z.object({ x: z.number() }), z.number())
+  double(@Ctx() _ctx: AppContext, @Input() input: { x: number }) {
+    return input.x * 2;
+  }
+}

--- a/examples/full-app/src/controllers/users.controller.ts
+++ b/examples/full-app/src/controllers/users.controller.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import {
+  Router,
+  Query,
+  Mutation,
+  UseZod,
+  UseMiddlewares,
+  Auth,
+  RateLimit,
+  Ctx,
+  Input,
+  Middleware,
+} from 'type-trpc';
+import type { AppContext } from '../context';
+import { UsersService } from '../services/users.service';
+
+const logger: Middleware = async ({ path, type, next }) => {
+  console.log(`[${type}] ${path}`);
+  return next();
+};
+
+@Router('users')
+@UseMiddlewares(logger)
+@Auth((ctx: AppContext) => (!!ctx.user ? true : 'UNAUTHORIZED'))
+export class UsersController {
+  constructor(private readonly users: UsersService) {}
+
+  @Query('getById')
+  @UseZod(z.object({ id: z.string().uuid() }))
+  @RateLimit({ points: 1, durationSec: 1 })
+  getById(@Ctx() _ctx: AppContext, @Input() input: { id: string }) {
+    return this.users.findById(input.id);
+  }
+
+  @Mutation('create')
+  @UseZod(z.object({ name: z.string().min(3), email: z.string().email() }))
+  @Auth((ctx: AppContext) => (ctx.user?.role === 'admin' ? true : 'FORBIDDEN'))
+  create(@Input() input: { name: string; email: string }) {
+    return this.users.create(input);
+  }
+}

--- a/examples/full-app/src/server.ts
+++ b/examples/full-app/src/server.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
+import { initTRPC } from '@trpc/server';
+import superjson from 'superjson';
+import { UsersController } from './controllers/users.controller';
+import { MathController } from './controllers/math.controller';
+import { UsersService } from './services/users.service';
+import type { AppContext } from './context';
+import { createClassRouter } from 'type-trpc';
+
+const t = initTRPC.context<AppContext>().create({
+  transformer: superjson,
+  errorFormatter({ shape, error }) {
+    return { ...shape, message: error.message };
+  },
+});
+
+const usersService = new UsersService();
+
+const { router: appRouter } = createClassRouter({
+  t,
+  controllers: [new UsersController(usersService), new MathController()],
+});
+
+export type AppRouter = typeof appRouter;
+export const createCaller = (ctx: AppContext) => appRouter.createCaller(ctx);
+
+export async function start() {
+  const app = express();
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: ({ req }) => {
+        const id = req.headers['x-user-id'];
+        const role = req.headers['x-user-role'];
+        if (typeof id === 'string' && (role === 'user' || role === 'admin')) {
+          return { user: { id, role } };
+        }
+        return {};
+      },
+    })
+  );
+  const port = 3000;
+  await app.listen(port);
+  console.log(`Server running on http://localhost:${port}/trpc`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  start();
+}

--- a/examples/full-app/src/services/users.service.ts
+++ b/examples/full-app/src/services/users.service.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'node:crypto';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: Date;
+}
+
+export class UsersService {
+  private users = new Map<string, User>();
+
+  findById(id: string): User | undefined {
+    return this.users.get(id);
+  }
+
+  create(data: { name: string; email: string }): User {
+    const user: User = { id: randomUUID(), createdAt: new Date(), ...data };
+    this.users.set(user.id, user);
+    return user;
+  }
+}

--- a/examples/full-app/tests/e2e.spec.ts
+++ b/examples/full-app/tests/e2e.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { createCaller } from '../src/server';
+
+describe('e2e', () => {
+  it('creates and fetches user', async () => {
+    const caller = createCaller({ user: { id: 'u1', role: 'admin' } });
+    const created = await caller.users.create({ name: 'Alice', email: 'alice@example.com' });
+    expect(created.createdAt).toBeInstanceOf(Date);
+    const fetched = await caller.users.getById({ id: created.id });
+    expect(fetched).toEqual(created);
+    await new Promise((r) => setTimeout(r, 1100));
+  });
+
+  it('rate limit', async () => {
+    const caller = createCaller({ user: { id: 'u1', role: 'admin' } });
+    const created = await caller.users.create({ name: 'Bob', email: 'bob@example.com' });
+    await caller.users.getById({ id: created.id });
+    await expect(caller.users.getById({ id: created.id })).rejects.toHaveProperty('code', 'TOO_MANY_REQUESTS');
+  });
+
+  it('zod error', async () => {
+    const caller = createCaller({ user: { id: 'u1', role: 'admin' } });
+    await expect(
+      caller.users.create({ name: 'Al', email: 'not-email' })
+    ).rejects.toHaveProperty('code', 'BAD_REQUEST');
+  });
+
+  it('unauthorized', async () => {
+    const caller = createCaller({});
+    await expect(
+      caller.users.create({ name: 'Alice', email: 'alice@example.com' })
+    ).rejects.toHaveProperty('code', 'UNAUTHORIZED');
+  });
+
+  it('forbidden', async () => {
+    const caller = createCaller({ user: { id: 'u2', role: 'user' } });
+    await expect(
+      caller.users.create({ name: 'Alice', email: 'alice@example.com' })
+    ).rejects.toHaveProperty('code', 'FORBIDDEN');
+  });
+
+  it('math.double', async () => {
+    const caller = createCaller({ user: { id: 'u1', role: 'admin' } });
+    expect(await caller.math.double({ x: 2 })).toBe(4);
+  });
+});

--- a/examples/full-app/tests/types.spec.ts
+++ b/examples/full-app/tests/types.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { createCaller } from '../src/server';
+import type { AppContext } from '../src/context';
+import { UsersController } from '../src/controllers/users.controller';
+import { MathController } from '../src/controllers/math.controller';
+import type { InferInput, InferOutput } from 'type-trpc';
+
+describe('types', () => {
+  it('users.getById', () => {
+    expectTypeOf<InferInput<UsersController, 'getById'>>().toEqualTypeOf<{ id: string }>();
+    expectTypeOf<InferOutput<UsersController, 'getById'>>().toEqualTypeOf<{
+      id: string;
+      name: string;
+      email: string;
+      createdAt: Date;
+    } | undefined>();
+  });
+
+  it('users.create', () => {
+    expectTypeOf<InferInput<UsersController, 'create'>>().toEqualTypeOf<{ name: string; email: string }>();
+    expectTypeOf<InferOutput<UsersController, 'create'>>().toEqualTypeOf<{
+      id: string;
+      name: string;
+      email: string;
+      createdAt: Date;
+    }>();
+  });
+
+  it('math.double', () => {
+    expectTypeOf<InferInput<MathController, 'double'>>().toEqualTypeOf<{ x: number }>();
+    expectTypeOf<InferOutput<MathController, 'double'>>().toEqualTypeOf<number>();
+  });
+
+  it('createCaller accepts AppContext', () => {
+    expectTypeOf(createCaller).parameters.toEqualTypeOf<[AppContext]>();
+  });
+});

--- a/examples/full-app/tsconfig.json
+++ b/examples/full-app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2020",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}

--- a/examples/full-app/vitest.config.ts
+++ b/examples/full-app/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { watch: false, threads: false, hookTimeout: 30000, testTimeout: 30000 },
+});


### PR DESCRIPTION
## Summary
- add a full example application using the decorator-based router
- include express server, services, controllers and client
- provide vitest e2e and type tests with npm scripts

## Testing
- `cd examples/full-app && npm test`
- `cd examples/full-app && npm run typecheck`
- `cd examples/full-app && npm run caller`


------
https://chatgpt.com/codex/tasks/task_e_68974a55abe883228de5ddcc4cd2dcf6