### PR TITLE
feat: type router return

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class UsersController {
 }
 
 const t = initTRPC.context().create({ transformer: superjson });
-const { router } = createClassRouter({
+const { router: appRouter } = createClassRouter({
   t,
   controllers: [new UsersController()],
   // register base procedures
@@ -56,6 +56,8 @@ const { router } = createClassRouter({
     }),
   },
 });
+
+export type AppRouter = typeof appRouter;
 ```
 
 ## Examples

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -9,14 +9,31 @@ import type { Middleware, AuthGuard } from './types';
 import { createRateLimitMiddleware } from './rateLimit';
 import { TRPCError } from '@trpc/server';
 
-export interface CreateClassRouterOptions {
-  t: any;
+import type {
+  AnyRouter,
+  AnyRootTypes,
+  Router,
+  RouterRecord,
+  RouterBuilder,
+  ProcedureBuilder,
+} from '@trpc/server';
+
+export interface CreateClassRouterOptions<TRoot extends AnyRootTypes> {
+  t: {
+    router: RouterBuilder<TRoot>;
+    mergeRouters: (...routers: AnyRouter[]) => AnyRouter;
+    procedure: ProcedureBuilder<TRoot>;
+  };
   controllers: any[];
   /** Global middlewares applied before class/method middlewares */
   middlewares?: Middleware[];
   /** Map of base procedures available via the {@link UseBase} decorator */
   baseProcedures?: Record<string, any>;
 }
+
+export type ClassRouter<TRoot extends AnyRootTypes> = {
+  router: Router<TRoot, RouterRecord> & RouterRecord;
+};
 
 function toCamel(str: string) {
   return str.charAt(0).toLowerCase() + str.slice(1);
@@ -35,16 +52,18 @@ function authMiddleware(guards: AuthGuard[]): Middleware {
   };
 }
 
-export function createClassRouter(options: CreateClassRouterOptions) {
+export function createClassRouter<TRoot extends AnyRootTypes>(
+  options: CreateClassRouterOptions<TRoot>,
+): ClassRouter<TRoot> {
   const { t, controllers, middlewares: globalMiddlewares = [], baseProcedures = {} } = options;
-  const rootProcedures: Record<string, any> = {};
+  const rootProcedures: RouterRecord = {};
 
   for (const controller of controllers) {
     const ctor = controller.constructor;
     const classMeta = getRouterMetadata(ctor);
     const base = classMeta.base ?? toCamel(ctor.name);
 
-    const procedures: Record<string, any> = {};
+    const procedures: RouterRecord = {};
     const proto = Object.getPrototypeOf(controller);
     for (const key of Object.getOwnPropertyNames(proto)) {
       if (key === 'constructor') continue;
@@ -92,7 +111,10 @@ export function createClassRouter(options: CreateClassRouterOptions) {
     if (!rootProcedures[base]) {
       rootProcedures[base] = t.router(procedures);
     } else {
-      rootProcedures[base] = t.mergeRouters(rootProcedures[base], t.router(procedures));
+      rootProcedures[base] = t.mergeRouters(
+        rootProcedures[base] as AnyRouter,
+        t.router(procedures),
+      );
     }
   }
 

--- a/tests/builder.spec.ts
+++ b/tests/builder.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
-import { initTRPC, TRPCError } from '@trpc/server';
+import { initTRPC, TRPCError, type AnyRouter, inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import superjson from 'superjson';
 import { z } from 'zod';
@@ -171,5 +171,15 @@ describe('createClassRouter', () => {
   it('infers types', () => {
     expectTypeOf<InferInput<UsersController, 'hello'>>().toEqualTypeOf<{ name: string }>();
     expectTypeOf<InferOutput<UsersController, 'add'>>().toEqualTypeOf<{ id: string; user?: string | undefined }>();
+  });
+
+  it('returns a typed router', () => {
+    expectTypeOf(router).toMatchTypeOf<AnyRouter>();
+    expectTypeOf(router).not.toBeAny();
+    type AppRouter = typeof router;
+    type Inputs = inferRouterInputs<AppRouter>;
+    type Outputs = inferRouterOutputs<AppRouter>;
+    expectTypeOf<Inputs>().toBeObject();
+    expectTypeOf<Outputs>().toBeObject();
   });
 });


### PR DESCRIPTION
## Summary
- type createClassRouter using tRPC Router types instead of `any`
- verify router type isn't `any` in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897429621d88322a49599c229edca31